### PR TITLE
feat(tg): author tracking E2E (closes #6, #7, #8, #9, #10, #11)

### DIFF
--- a/api/cron/telegram-authors.ts
+++ b/api/cron/telegram-authors.ts
@@ -1,0 +1,4 @@
+import { withCronAuth } from "./_helpers.js"
+import { runTelegramAuthors } from "../../src/sources/telegram/pipeline.js"
+
+export default withCronAuth("telegram-authors", () => runTelegramAuthors())

--- a/scripts/migrate-authors.ts
+++ b/scripts/migrate-authors.ts
@@ -1,0 +1,18 @@
+import "dotenv/config"
+import { Redis } from "@upstash/redis"
+import { kv } from "../src/config.js"
+
+const OLD = "authors:tracked"
+const NEW = "authors:tracked:alenka"
+
+const redis = new Redis({ url: kv.url, token: kv.token })
+
+const members = await redis.smembers(OLD)
+if (!members.length) {
+  console.log(`No-op: ${OLD} empty.`)
+  process.exit(0)
+}
+
+await redis.sadd(NEW, members[0], ...members.slice(1))
+await redis.del(OLD)
+console.log(`Migrated ${members.length} authors → ${NEW}: ${members.join(", ")}`)

--- a/src/bot-commands.ts
+++ b/src/bot-commands.ts
@@ -116,12 +116,12 @@ async function handleStatus(ctx: Context, store: Store) {
     store.getFolder(),
     store.getSubscribers(),
     store.getTrackedTopics(),
-    store.getTrackedAuthors(),
+    store.getTrackedAuthors("alenka"),
     store.getLastId("authors"),
   ])
   const sourceNames = getSources().map((s) => s.label).join(", ")
   await ctx.reply(
-    `ℹ️ Статус:\n• Runtime: ${runtime}\n• LLM: ${llm.uri}\n• Sources: ${sourceNames}\n• Папка TG: ${folder ?? "—"}\n• Топиков: ${topics.length}\n• Авторов: ${authors.length}\n• Authors lastId: ${authorsId ?? "—"}\n• Подписчиков: ${subs.length}`,
+    `ℹ️ Статус:\n• Runtime: ${runtime}\n• LLM: ${llm.uri}\n• Sources: ${sourceNames}\n• Папка TG: ${folder ?? "—"}\n• Топиков: ${topics.length}\n• Авторов Alёnka: ${authors.length}\n• Authors lastId: ${authorsId ?? "—"}\n• Подписчиков: ${subs.length}`,
   )
 }
 
@@ -299,10 +299,10 @@ export function registerCommands(bot: Bot, store: Store) {
     emptyMsg: "Нет авторов. /follow <имя>",
     addMsg: (n) => `✅ Отслеживаю: ${n}`,
     removeMsg: (n) => `🗑️ Больше не отслеживаю: ${n}`,
-    getAll: () => store.getTrackedAuthors(),
-    isTracked: (n) => store.isTrackedAuthor(n),
-    track: (n) => store.trackAuthor(n),
-    untrack: (n) => store.untrackAuthor(n),
+    getAll: () => store.getTrackedAuthors("alenka"),
+    isTracked: (n) => store.isTrackedAuthor("alenka", n),
+    track: (n) => store.trackAuthor("alenka", n),
+    untrack: (n) => store.untrackAuthor("alenka", n),
   }))
 
   bot.command("status", adminOnly(async (ctx) => handleStatus(ctx, store)))

--- a/src/bot-commands.ts
+++ b/src/bot-commands.ts
@@ -5,7 +5,8 @@ import type { Store, Session } from "./store.js"
 import { startKeyboard, sourceKeyboard, promptKeyboard, repeatKeyboard, resolveButton, DEFAULT_DURATION_MS, REPEAT_PREFIX, type ButtonAction } from "./keyboard.js"
 import { getSources } from "./sources/registry.js"
 import { runTrends, runTopics } from "./pipeline.js"
-import { runAuthors, runHot } from "./sources/alenka/pipeline.js"
+import { runHot } from "./sources/alenka/pipeline.js"
+import { runAuthorsForSource } from "./sources/authors-dispatch.js"
 import { normalizeTgUsername } from "./sources/telegram/username.js"
 import { resolveTgUsername } from "./sources/telegram/resolve.js"
 import { followUp } from "./analyzer.js"
@@ -101,15 +102,14 @@ async function runAndReply(
 const AUTHORS_PAGE = 10
 
 async function handleAuthors(ctx: Context, store: Store) {
-  const source = await resolveSource(store, chatId(ctx))
-  if (source === "telegram") {
-    await ctx.reply("⏳ TG-pipeline ещё не подключён (см. #11).")
-    return
-  }
-  return execWithReply(ctx, "Authors", () => runAuthors({ store, api: ctx.api, maxAlerts: AUTHORS_PAGE }),
+  const source = await resolveSource(store, chatId(ctx)) as "alenka" | "telegram"
+  return execWithReply(ctx, "Authors",
+    () => runAuthorsForSource(source, { store, api: ctx.api, maxAlerts: AUTHORS_PAGE }),
     (r) => r.alerts >= AUTHORS_PAGE
       ? `✅ ${r.alerts} алертов. Нажмите ещё раз для следующих.`
-      : `✅ ${r.comments} комментариев, ${r.alerts} алертов.`)
+      : r.comments != null
+        ? `✅ ${r.comments} комментариев, ${r.alerts} алертов.`
+        : `✅ ${r.alerts} алертов.`)
 }
 
 function handleHot(ctx: Context, store: Store) {

--- a/src/bot-commands.ts
+++ b/src/bot-commands.ts
@@ -6,6 +6,8 @@ import { startKeyboard, sourceKeyboard, promptKeyboard, repeatKeyboard, resolveB
 import { getSources } from "./sources/registry.js"
 import { runTrends, runTopics } from "./pipeline.js"
 import { runAuthors, runHot } from "./sources/alenka/pipeline.js"
+import { normalizeTgUsername } from "./sources/telegram/username.js"
+import { resolveTgUsername } from "./sources/telegram/resolve.js"
 import { followUp } from "./analyzer.js"
 import { llm, telegram } from "./config.js"
 
@@ -98,7 +100,12 @@ async function runAndReply(
 
 const AUTHORS_PAGE = 10
 
-function handleAuthors(ctx: Context, store: Store) {
+async function handleAuthors(ctx: Context, store: Store) {
+  const source = await resolveSource(store, chatId(ctx))
+  if (source === "telegram") {
+    await ctx.reply("⏳ TG-pipeline ещё не подключён (см. #11).")
+    return
+  }
   return execWithReply(ctx, "Authors", () => runAuthors({ store, api: ctx.api, maxAlerts: AUTHORS_PAGE }),
     (r) => r.alerts >= AUTHORS_PAGE
       ? `✅ ${r.alerts} алертов. Нажмите ещё раз для следующих.`
@@ -112,16 +119,17 @@ function handleHot(ctx: Context, store: Store) {
 
 async function handleStatus(ctx: Context, store: Store) {
   const runtime = process.env.VERCEL ? "Vercel" : `Local (${hostname()})`
-  const [folder, subs, topics, authors, authorsId] = await Promise.all([
+  const [folder, subs, topics, alenkaAuthors, tgAuthors, authorsId] = await Promise.all([
     store.getFolder(),
     store.getSubscribers(),
     store.getTrackedTopics(),
     store.getTrackedAuthors("alenka"),
+    store.getTrackedAuthors("telegram"),
     store.getLastId("authors"),
   ])
   const sourceNames = getSources().map((s) => s.label).join(", ")
   await ctx.reply(
-    `ℹ️ Статус:\n• Runtime: ${runtime}\n• LLM: ${llm.uri}\n• Sources: ${sourceNames}\n• Папка TG: ${folder ?? "—"}\n• Топиков: ${topics.length}\n• Авторов Alёnka: ${authors.length}\n• Authors lastId: ${authorsId ?? "—"}\n• Подписчиков: ${subs.length}`,
+    `ℹ️ Статус:\n• Runtime: ${runtime}\n• LLM: ${llm.uri}\n• Sources: ${sourceNames}\n• Папка TG: ${folder ?? "—"}\n• Топиков: ${topics.length}\n• Авторов Alёnka: ${alenkaAuthors.length} · Telegram: ${tgAuthors.length}\n• Authors lastId: ${authorsId ?? "—"}\n• Подписчиков: ${subs.length}`,
   )
 }
 
@@ -263,6 +271,86 @@ function toggleCommand(store: Store, cfg: ToggleConfig) {
   }, ADMIN_DENIED)
 }
 
+const AUTHORS_SOURCE_TITLE: Record<string, string> = {
+  alenka: "📝 Авторы Alёnka",
+  telegram: "📝 Авторы Telegram",
+}
+
+function formatAuthorsSection(source: string, names: string[]): string {
+  return `${AUTHORS_SOURCE_TITLE[source]}:\n${names.map((n) => `• <code>${n}</code>`).join("\n")}`
+}
+
+function followCommand(store: Store) {
+  return adminOnly(async (ctx: Context) => {
+    const arg = ctx.match?.toString().trim()
+    if (!arg) {
+      const explicitSource = await store.getUserSource(chatId(ctx))
+      if (explicitSource) {
+        const names = await store.getTrackedAuthors(explicitSource as "alenka" | "telegram")
+        if (!names.length) return ctx.reply("Нет авторов. /follow имя или /follow @username")
+        return ctx.reply(formatAuthorsSection(explicitSource, names), { parse_mode: "HTML" })
+      }
+      const [alenka, telegram] = await Promise.all([
+        store.getTrackedAuthors("alenka"),
+        store.getTrackedAuthors("telegram"),
+      ])
+      const sections = [
+        ...(alenka.length ? [formatAuthorsSection("alenka", alenka)] : []),
+        ...(telegram.length ? [formatAuthorsSection("telegram", telegram)] : []),
+      ]
+      if (!sections.length) return ctx.reply("Нет авторов. /follow имя или /follow @username")
+      return ctx.reply(sections.join("\n\n"), { parse_mode: "HTML" })
+    }
+
+    const chat = chatId(ctx)
+    const explicitSource = await store.getUserSource(chat)
+    const source = explicitSource || "alenka"
+    const fallbackSuffix = explicitSource ? "" : " (Alёnka — по умолчанию)"
+
+    if (source === "telegram") {
+      return followTelegramAuthor(ctx, store, arg)
+    }
+
+    return toggleAlenkaAuthor(ctx, store, arg, fallbackSuffix)
+  }, ADMIN_DENIED)
+}
+
+async function toggleAlenkaAuthor(ctx: Context, store: Store, name: string, suffix: string): Promise<void> {
+  if (await store.isTrackedAuthor("alenka", name)) {
+    await store.untrackAuthor("alenka", name)
+    await ctx.reply(`🗑️ Больше не отслеживаю: ${name}${suffix}`)
+  } else {
+    await store.trackAuthor("alenka", name)
+    await ctx.reply(`✅ Отслеживаю: ${name}${suffix}`)
+  }
+}
+
+async function followTelegramAuthor(ctx: Context, store: Store, raw: string): Promise<void> {
+  const username = normalizeTgUsername(raw)
+  if (!username) {
+    await ctx.reply("❌ Неверный формат. Используйте /follow @username")
+    return
+  }
+
+  if (await store.isTrackedAuthor("telegram", username)) {
+    await store.untrackAuthor("telegram", username)
+    await store.deleteResolvedTgUser(username)
+    await ctx.reply(`🗑️ Больше не отслеживаю: @${username}`)
+    return
+  }
+
+  await ctx.replyWithChatAction("typing")
+  const resolved = await resolveTgUsername(username)
+  if (!resolved) {
+    await ctx.reply(`❌ Юзернейм @${username} не найден`)
+    return
+  }
+
+  await store.setResolvedTgUser(username, resolved)
+  await store.trackAuthor("telegram", username)
+  await ctx.reply(`✅ Отслеживаю: @${username}`)
+}
+
 function analysisCommand(store: Store, mode: "trends" | "topics") {
   return adminOnly(async (ctx: Context) => {
     const { durationMs, customArg } = parseCommandArgs(ctx.match?.toString())
@@ -294,16 +382,7 @@ export function registerCommands(bot: Bot, store: Store) {
     untrack: (n) => store.untrackTopic(n),
   }))
 
-  bot.command("follow", toggleCommand(store, {
-    title: "📝 Авторы",
-    emptyMsg: "Нет авторов. /follow <имя>",
-    addMsg: (n) => `✅ Отслеживаю: ${n}`,
-    removeMsg: (n) => `🗑️ Больше не отслеживаю: ${n}`,
-    getAll: () => store.getTrackedAuthors("alenka"),
-    isTracked: (n) => store.isTrackedAuthor("alenka", n),
-    track: (n) => store.trackAuthor("alenka", n),
-    untrack: (n) => store.untrackAuthor("alenka", n),
-  }))
+  bot.command("follow", followCommand(store))
 
   bot.command("status", adminOnly(async (ctx) => handleStatus(ctx, store)))
   bot.command("trends", analysisCommand(store, "trends"))

--- a/src/bot-commands.ts
+++ b/src/bot-commands.ts
@@ -6,7 +6,7 @@ import { startKeyboard, sourceKeyboard, promptKeyboard, repeatKeyboard, resolveB
 import { getSources } from "./sources/registry.js"
 import { runTrends, runTopics } from "./pipeline.js"
 import { runHot } from "./sources/alenka/pipeline.js"
-import { runAuthorsForSource } from "./sources/authors-dispatch.js"
+import { runAuthorsForSource, isAuthorsSource, type AuthorsSource } from "./sources/authors-dispatch.js"
 import { normalizeTgUsername } from "./sources/telegram/username.js"
 import { resolveTgUsername } from "./sources/telegram/resolve.js"
 import { followUp } from "./analyzer.js"
@@ -45,6 +45,11 @@ async function withTyping<T>(ctx: Context, fn: () => Promise<T>): Promise<T> {
 
 async function resolveSource(store: Store, chat: string): Promise<string> {
   return (await store.getUserSource(chat)) || getSources()[0].name
+}
+
+async function resolveAuthorsSource(store: Store, chat: string): Promise<AuthorsSource> {
+  const explicit = await store.getUserSource(chat)
+  return explicit && isAuthorsSource(explicit) ? explicit : "alenka"
 }
 
 function parseDuration(input: string): number | undefined {
@@ -102,7 +107,7 @@ async function runAndReply(
 const AUTHORS_PAGE = 10
 
 async function handleAuthors(ctx: Context, store: Store) {
-  const source = await resolveSource(store, chatId(ctx)) as "alenka" | "telegram"
+  const source = await resolveAuthorsSource(store, chatId(ctx))
   return execWithReply(ctx, "Authors",
     () => runAuthorsForSource(source, { store, api: ctx.api, maxAlerts: AUTHORS_PAGE }),
     (r) => r.alerts >= AUTHORS_PAGE
@@ -283,10 +288,13 @@ function formatAuthorsSection(source: string, names: string[]): string {
 function followCommand(store: Store) {
   return adminOnly(async (ctx: Context) => {
     const arg = ctx.match?.toString().trim()
+    const chat = chatId(ctx)
+    const explicitRaw = await store.getUserSource(chat)
+    const explicitSource = explicitRaw && isAuthorsSource(explicitRaw) ? explicitRaw : null
+
     if (!arg) {
-      const explicitSource = await store.getUserSource(chatId(ctx))
       if (explicitSource) {
-        const names = await store.getTrackedAuthors(explicitSource as "alenka" | "telegram")
+        const names = await store.getTrackedAuthors(explicitSource)
         if (!names.length) return ctx.reply("Нет авторов. /follow имя или /follow @username")
         return ctx.reply(formatAuthorsSection(explicitSource, names), { parse_mode: "HTML" })
       }
@@ -302,9 +310,7 @@ function followCommand(store: Store) {
       return ctx.reply(sections.join("\n\n"), { parse_mode: "HTML" })
     }
 
-    const chat = chatId(ctx)
-    const explicitSource = await store.getUserSource(chat)
-    const source = explicitSource || "alenka"
+    const source: AuthorsSource = explicitSource ?? "alenka"
     const fallbackSuffix = explicitSource ? "" : " (Alёnka — по умолчанию)"
 
     if (source === "telegram") {

--- a/src/sources/alenka/index.ts
+++ b/src/sources/alenka/index.ts
@@ -52,9 +52,8 @@ export function toMessage(c: Comment): Message {
     replyTo: c.replyTo,
     likes: c.likes,
     images: c.images,
-    articleTitle: c.articleTitle,
-    articleUrl: c.articleUrl,
-    commentUrl: c.commentUrl,
+    linkTitle: c.articleTitle,
+    linkUrl: c.commentUrl,
   }
 }
 

--- a/src/sources/alenka/pipeline.ts
+++ b/src/sources/alenka/pipeline.ts
@@ -41,7 +41,7 @@ export async function runAuthors(opts: AlenkaOpts = {}): Promise<AuthorsResult> 
       return { comments: 0, alerts: 0 }
     }
 
-    const [tracked, subs] = await Promise.all([store.getTrackedAuthors(), store.getSubscribers()])
+    const [tracked, subs] = await Promise.all([store.getTrackedAuthors("alenka"), store.getSubscribers()])
     console.log(`Tracked: ${tracked.length ? tracked.join(", ") : "none"}`)
     console.log(`Scraping new comments (lastId=${lastId})...`)
 

--- a/src/sources/authors-dispatch.test.ts
+++ b/src/sources/authors-dispatch.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest"
+import { runAuthorsForSource } from "./authors-dispatch.js"
+
+describe("runAuthorsForSource", () => {
+  it("source=alenka → calls runAuthors with opts", async () => {
+    const runAlenka = vi.fn().mockResolvedValue({ comments: 5, alerts: 2 })
+    const runTelegram = vi.fn().mockResolvedValue({ alerts: 0 })
+    const opts = { maxAlerts: 10 } as any
+    const result = await runAuthorsForSource("alenka", opts, { runAlenka, runTelegram })
+    expect(runAlenka).toHaveBeenCalledWith(opts)
+    expect(runTelegram).not.toHaveBeenCalled()
+    expect(result).toEqual({ alerts: 2, comments: 5 })
+  })
+
+  it("source=telegram → calls runTelegramAuthors with opts", async () => {
+    const runAlenka = vi.fn().mockResolvedValue({ comments: 0, alerts: 0 })
+    const runTelegram = vi.fn().mockResolvedValue({ alerts: 7 })
+    const opts = { maxAlerts: 10 } as any
+    const result = await runAuthorsForSource("telegram", opts, { runAlenka, runTelegram })
+    expect(runTelegram).toHaveBeenCalledWith(opts)
+    expect(runAlenka).not.toHaveBeenCalled()
+    expect(result).toEqual({ alerts: 7 })
+  })
+})

--- a/src/sources/authors-dispatch.test.ts
+++ b/src/sources/authors-dispatch.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect, vi } from "vitest"
-import { runAuthorsForSource } from "./authors-dispatch.js"
+import { AUTHORS_SOURCES, isAuthorsSource, runAuthorsForSource } from "./authors-dispatch.js"
+
+describe("isAuthorsSource", () => {
+  it("accepts known sources", () => {
+    expect(isAuthorsSource("alenka")).toBe(true)
+    expect(isAuthorsSource("telegram")).toBe(true)
+  })
+
+  it("rejects unknown / empty / case-mismatched values", () => {
+    expect(isAuthorsSource("Alenka")).toBe(false)
+    expect(isAuthorsSource("twitter")).toBe(false)
+    expect(isAuthorsSource("")).toBe(false)
+  })
+
+  it("AUTHORS_SOURCES enumerates exactly the supported sources", () => {
+    expect([...AUTHORS_SOURCES].sort()).toEqual(["alenka", "telegram"])
+  })
+})
 
 describe("runAuthorsForSource", () => {
   it("source=alenka → calls runAuthors with opts", async () => {

--- a/src/sources/authors-dispatch.ts
+++ b/src/sources/authors-dispatch.ts
@@ -3,7 +3,10 @@ import { Api } from "grammy"
 import { runAuthors as defaultRunAuthors } from "./alenka/pipeline.js"
 import { runTelegramAuthors as defaultRunTelegram } from "./telegram/pipeline.js"
 
-export type AuthorsSource = "alenka" | "telegram"
+export const AUTHORS_SOURCES = ["alenka", "telegram"] as const
+export type AuthorsSource = (typeof AUTHORS_SOURCES)[number]
+export const isAuthorsSource = (s: string): s is AuthorsSource =>
+  (AUTHORS_SOURCES as readonly string[]).includes(s)
 
 export interface AuthorsDispatchOpts {
   store?: Store

--- a/src/sources/authors-dispatch.ts
+++ b/src/sources/authors-dispatch.ts
@@ -1,0 +1,37 @@
+import type { Store } from "../store.js"
+import { Api } from "grammy"
+import { runAuthors as defaultRunAuthors } from "./alenka/pipeline.js"
+import { runTelegramAuthors as defaultRunTelegram } from "./telegram/pipeline.js"
+
+export type AuthorsSource = "alenka" | "telegram"
+
+export interface AuthorsDispatchOpts {
+  store?: Store
+  api?: Api
+  maxAlerts?: number
+}
+
+export interface AuthorsDispatchResult {
+  alerts: number
+  comments?: number
+}
+
+export interface DispatchDeps {
+  runAlenka?: (opts: AuthorsDispatchOpts) => Promise<{ comments: number; alerts: number }>
+  runTelegram?: (opts: AuthorsDispatchOpts) => Promise<{ alerts: number }>
+}
+
+export async function runAuthorsForSource(
+  source: AuthorsSource,
+  opts: AuthorsDispatchOpts,
+  deps: DispatchDeps = {},
+): Promise<AuthorsDispatchResult> {
+  const runAlenka = deps.runAlenka ?? defaultRunAuthors
+  const runTelegram = deps.runTelegram ?? defaultRunTelegram
+  if (source === "telegram") {
+    const r = await runTelegram(opts)
+    return { alerts: r.alerts }
+  }
+  const r = await runAlenka(opts)
+  return { alerts: r.alerts, comments: r.comments }
+}

--- a/src/sources/registry.test.ts
+++ b/src/sources/registry.test.ts
@@ -24,8 +24,8 @@ describe("registry", () => {
     expect(source.capabilities).toEqual(["trends", "topics", "authors", "hot"])
   })
 
-  it("telegram has trends and topics", () => {
+  it("telegram has trends, topics and authors", () => {
     const source = getSource("telegram")
-    expect(source.capabilities).toEqual(["trends", "topics"])
+    expect(source.capabilities).toEqual(["trends", "topics", "authors"])
   })
 })

--- a/src/sources/telegram/index.ts
+++ b/src/sources/telegram/index.ts
@@ -10,7 +10,7 @@ export function createTelegramSource(store: Store): Source {
     label: "Telegram",
     displayName: "Telegram",
     iconId: "5810150084930702668",
-    capabilities: ["trends", "topics"],
+    capabilities: ["trends", "topics", "authors"],
 
     async fetchMessages(since: Date): Promise<Message[]> {
       const folderName = await store.getFolder()

--- a/src/sources/telegram/link.test.ts
+++ b/src/sources/telegram/link.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest"
+import { buildMessageLink } from "./link.js"
+
+describe("buildMessageLink", () => {
+  it("public chat with username → t.me/{username}/{msgId}", () => {
+    expect(buildMessageLink("-1001234567890", 42, "durov")).toBe("https://t.me/durov/42")
+  })
+
+  it("private chat without username → t.me/c/{strippedId}/{msgId}", () => {
+    expect(buildMessageLink("-1001234567890", 42)).toBe("https://t.me/c/1234567890/42")
+  })
+
+  it("strips -100 prefix from BigInt-safe chatId", () => {
+    expect(buildMessageLink("-1009999999999999", 1)).toBe("https://t.me/c/9999999999999/1")
+  })
+
+  it("private chatId without -100 prefix passes through unsigned abs", () => {
+    expect(buildMessageLink("-12345", 7)).toBe("https://t.me/c/12345/7")
+  })
+})

--- a/src/sources/telegram/link.ts
+++ b/src/sources/telegram/link.ts
@@ -1,0 +1,5 @@
+export function buildMessageLink(chatId: string, msgId: number, chatUsername?: string): string {
+  if (chatUsername) return `https://t.me/${chatUsername}/${msgId}`
+  const stripped = chatId.startsWith("-100") ? chatId.slice(4) : chatId.replace(/^-/, "")
+  return `https://t.me/c/${stripped}/${msgId}`
+}

--- a/src/sources/telegram/pipeline.test.ts
+++ b/src/sources/telegram/pipeline.test.ts
@@ -17,6 +17,19 @@ function fakeStore(overrides: Partial<Record<string, any>> = {}) {
   } as any
 }
 
+function chanPeer(id: number) {
+  return new Api.InputPeerChannel({ channelId: BigInt(id) as any, accessHash: BigInt(id * 10) as any })
+}
+function dmPeer(id: number) {
+  return new Api.InputPeerUser({ userId: BigInt(id) as any, accessHash: BigInt(id * 10) as any })
+}
+
+function msg(id: string, ts: number, author = "@durov", chatId = "c"): Message {
+  return { id, chatId, chatTitle: "T", author, text: id, date: new Date(ts * 1000) }
+}
+
+const mkAuthor = (username: string, userId: string) => ({ username, resolved: { userId, accessHash: "1" } })
+
 describe("runTelegramAuthors", () => {
   it("cold-start: empty lastTs sets to now and returns 0 alerts without contacting client", async () => {
     const store = fakeStore({ getTgAuthorsLastTs: vi.fn().mockResolvedValue(null) })
@@ -47,35 +60,15 @@ describe("runTelegramAuthors", () => {
   })
 })
 
-const author = { username: "durov", resolved: { userId: "1", accessHash: "2" } }
-
-function chanPeer(id: number) {
-  return new Api.InputPeerChannel({ channelId: BigInt(id) as any, accessHash: BigInt(id * 10) as any })
-}
-function dmPeer(id: number) {
-  return new Api.InputPeerUser({ userId: BigInt(id) as any, accessHash: BigInt(id * 10) as any })
-}
-
-function fakeSearch(per: Map<string, Message[]>) {
-  return vi.fn(async (_client: any, peer: any, _resolved: any, sinceTs: number) => {
-    const key = peer instanceof Api.InputPeerChannel ? `ch:${peer.channelId}` : peer instanceof Api.InputPeerUser ? `u:${peer.userId}` : "?"
-    const msgs = per.get(key) ?? []
-    const newLastTs = msgs.length ? Math.max(...msgs.map((m) => Math.floor(m.date.getTime() / 1000))) : sinceTs
-    return { messages: msgs, newLastTs }
-  })
-}
-
-function msg(id: string, ts: number, text = id): Message {
-  return { id, chatId: "c", chatTitle: "T", author: "@durov", text, date: new Date(ts * 1000) }
-}
-
 describe("collectAuthorAlerts", () => {
   it("skips DM peers (InputPeerUser) — never invokes search on them", async () => {
-    const search = fakeSearch(new Map([["ch:1", [msg("1", 100)]]]))
+    const search = vi.fn(async (_c: any, peer: any) =>
+      peer instanceof Api.InputPeerChannel ? [msg("1", 100)] : [],
+    )
     const result = await collectAuthorAlerts({
       client: {} as any,
       peers: [chanPeer(1), dmPeer(99)],
-      resolvedAuthors: [author],
+      resolvedAuthors: [mkAuthor("durov", "1")],
       lastTs: 0,
       maxAlerts: 10,
       search,
@@ -88,33 +81,85 @@ describe("collectAuthorAlerts", () => {
     expect(calledPeer).toBeInstanceOf(Api.InputPeerChannel)
   })
 
-  it("truncates total alerts to maxAlerts", async () => {
-    const many = Array.from({ length: 8 }, (_, i) => msg(String(i + 1), 100 + i))
-    const search = fakeSearch(new Map([["ch:1", many], ["ch:2", many]]))
+  it("aggregates from every (chat × author) and selects 10 globally oldest", async () => {
+    // 2 chats × 2 authors × 4 msgs = 16 msgs total
+    // chat 1, durov(1): 100, 200, 300, 400
+    // chat 1, elvis(2): 150, 250, 350, 450
+    // chat 2, durov(1):  50, 175, 275, 375
+    // chat 2, elvis(2):  75, 125, 225, 325
+    // pool (sorted): 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400, 450
+    // first 10:      50, 75, 100, 125, 150, 175, 200, 225, 250, 275  (newLastTs = 275)
+    const dataset: Record<string, number[]> = {
+      "ch1:1": [100, 200, 300, 400],
+      "ch1:2": [150, 250, 350, 450],
+      "ch2:1": [50, 175, 275, 375],
+      "ch2:2": [75, 125, 225, 325],
+    }
+    const search = vi.fn(async (_c: any, peer: any, resolved: any) => {
+      const peerKey = peer instanceof Api.InputPeerChannel ? `ch${peer.channelId}` : "?"
+      const dates = dataset[`${peerKey}:${resolved.userId}`] ?? []
+      return dates.map((d) => msg(`${peerKey}-${resolved.userId}-${d}`, d))
+    })
+
     const result = await collectAuthorAlerts({
       client: {} as any,
       peers: [chanPeer(1), chanPeer(2)],
-      resolvedAuthors: [author],
+      resolvedAuthors: [mkAuthor("durov", "1"), mkAuthor("elvis", "2")],
       lastTs: 0,
       maxAlerts: 10,
       search,
       resolveContext: async () => ({ chatId: "-1001", chatTitle: "T" }),
       delay: () => Promise.resolve(),
     })
+
+    expect(search).toHaveBeenCalledTimes(4)
     expect(result.alerts).toHaveLength(10)
+    const dates = result.alerts.map((a: any) => Math.floor(a.comment.date.getTime() / 1000))
+    expect(dates).toEqual([50, 75, 100, 125, 150, 175, 200, 225, 250, 275])
+    expect(result.newLastTs).toBe(275)
   })
 
-  it("PEER_ID_INVALID / USER_DEACTIVATED on author → eviction surfaced, loop continues with next author", async () => {
-    const goodAuthor = { username: "good", resolved: { userId: "1", accessHash: "1" } }
-    const badAuthor = { username: "bad", resolved: { userId: "2", accessHash: "2" } }
+  it("pool smaller than maxAlerts → returns all, newLastTs = newest selected", async () => {
+    const search = vi.fn(async () => [msg("a", 100), msg("b", 300), msg("c", 200)])
+    const result = await collectAuthorAlerts({
+      client: {} as any,
+      peers: [chanPeer(1)],
+      resolvedAuthors: [mkAuthor("durov", "1")],
+      lastTs: 50,
+      maxAlerts: 10,
+      search,
+      resolveContext: async () => ({ chatId: "-1001", chatTitle: "T" }),
+      delay: () => Promise.resolve(),
+    })
+    expect(result.alerts).toHaveLength(3)
+    expect(result.newLastTs).toBe(300)
+  })
+
+  it("empty pool → keeps lastTs unchanged", async () => {
+    const search = vi.fn(async () => [])
+    const result = await collectAuthorAlerts({
+      client: {} as any,
+      peers: [chanPeer(1)],
+      resolvedAuthors: [mkAuthor("durov", "1")],
+      lastTs: 999,
+      maxAlerts: 10,
+      search,
+      resolveContext: async () => ({ chatId: "-1001", chatTitle: "T" }),
+      delay: () => Promise.resolve(),
+    })
+    expect(result.alerts).toEqual([])
+    expect(result.newLastTs).toBe(999)
+  })
+
+  it("PEER_ID_INVALID / USER_DEACTIVATED on author → eviction surfaced, loop continues", async () => {
     const search = vi.fn(async (_c: any, _peer: any, resolved: any) => {
       if (resolved.userId === "2") throw new Error("PEER_ID_INVALID")
-      return { messages: [msg("1", 100)], newLastTs: 100 }
+      return [msg("1", 100)]
     })
     const result = await collectAuthorAlerts({
       client: {} as any,
       peers: [chanPeer(1)],
-      resolvedAuthors: [badAuthor, goodAuthor],
+      resolvedAuthors: [mkAuthor("bad", "2"), mkAuthor("good", "1")],
       lastTs: 0,
       maxAlerts: 10,
       search,
@@ -126,16 +171,14 @@ describe("collectAuthorAlerts", () => {
   })
 
   it("non-eviction errors are not surfaced as evictions but loop continues", async () => {
-    const a = { username: "a", resolved: { userId: "1", accessHash: "1" } }
-    const b = { username: "b", resolved: { userId: "2", accessHash: "2" } }
     const search = vi.fn(async (_c: any, _peer: any, resolved: any) => {
       if (resolved.userId === "1") throw new Error("FLOOD_WAIT_42")
-      return { messages: [msg("1", 100)], newLastTs: 100 }
+      return [msg("1", 100)]
     })
     const result = await collectAuthorAlerts({
       client: {} as any,
       peers: [chanPeer(1)],
-      resolvedAuthors: [a, b],
+      resolvedAuthors: [mkAuthor("a", "1"), mkAuthor("b", "2")],
       lastTs: 0,
       maxAlerts: 10,
       search,

--- a/src/sources/telegram/pipeline.test.ts
+++ b/src/sources/telegram/pipeline.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi } from "vitest"
+import { Api } from "telegram/tl/index.js"
+import { collectAuthorAlerts, runTelegramAuthors } from "./pipeline.js"
+import type { Message } from "../../types.js"
+
+function fakeStore(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    getTrackedAuthors: vi.fn().mockResolvedValue(["durov"]),
+    getTgAuthorsLastTs: vi.fn().mockResolvedValue(null),
+    setTgAuthorsLastTs: vi.fn().mockResolvedValue(undefined),
+    getResolvedTgUser: vi.fn().mockResolvedValue({ userId: "1", accessHash: "2" }),
+    setResolvedTgUser: vi.fn().mockResolvedValue(undefined),
+    deleteResolvedTgUser: vi.fn().mockResolvedValue(undefined),
+    getFolder: vi.fn().mockResolvedValue("invest"),
+    getSubscribers: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as any
+}
+
+describe("runTelegramAuthors", () => {
+  it("cold-start: empty lastTs sets to now and returns 0 alerts without contacting client", async () => {
+    const store = fakeStore({ getTgAuthorsLastTs: vi.fn().mockResolvedValue(null) })
+    const createClient = vi.fn()
+
+    const before = Math.floor(Date.now() / 1000)
+    const result = await runTelegramAuthors({ store, createClient } as any)
+    const after = Math.floor(Date.now() / 1000)
+
+    expect(result.alerts).toBe(0)
+    expect(createClient).not.toHaveBeenCalled()
+    expect(store.setTgAuthorsLastTs).toHaveBeenCalledTimes(1)
+    const ts = store.setTgAuthorsLastTs.mock.calls[0][0]
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(after)
+  })
+
+  it("empty tracked authors → returns 0 alerts without creating client or touching lastTs", async () => {
+    const store = fakeStore({ getTrackedAuthors: vi.fn().mockResolvedValue([]) })
+    const createClient = vi.fn()
+
+    const result = await runTelegramAuthors({ store, createClient } as any)
+
+    expect(result.alerts).toBe(0)
+    expect(createClient).not.toHaveBeenCalled()
+    expect(store.getTgAuthorsLastTs).not.toHaveBeenCalled()
+    expect(store.setTgAuthorsLastTs).not.toHaveBeenCalled()
+  })
+})
+
+const author = { username: "durov", resolved: { userId: "1", accessHash: "2" } }
+
+function chanPeer(id: number) {
+  return new Api.InputPeerChannel({ channelId: BigInt(id) as any, accessHash: BigInt(id * 10) as any })
+}
+function dmPeer(id: number) {
+  return new Api.InputPeerUser({ userId: BigInt(id) as any, accessHash: BigInt(id * 10) as any })
+}
+
+function fakeSearch(per: Map<string, Message[]>) {
+  return vi.fn(async (_client: any, peer: any, _resolved: any, sinceTs: number) => {
+    const key = peer instanceof Api.InputPeerChannel ? `ch:${peer.channelId}` : peer instanceof Api.InputPeerUser ? `u:${peer.userId}` : "?"
+    const msgs = per.get(key) ?? []
+    const newLastTs = msgs.length ? Math.max(...msgs.map((m) => Math.floor(m.date.getTime() / 1000))) : sinceTs
+    return { messages: msgs, newLastTs }
+  })
+}
+
+function msg(id: string, ts: number, text = id): Message {
+  return { id, chatId: "c", chatTitle: "T", author: "@durov", text, date: new Date(ts * 1000) }
+}
+
+describe("collectAuthorAlerts", () => {
+  it("skips DM peers (InputPeerUser) — never invokes search on them", async () => {
+    const search = fakeSearch(new Map([["ch:1", [msg("1", 100)]]]))
+    const result = await collectAuthorAlerts({
+      client: {} as any,
+      peers: [chanPeer(1), dmPeer(99)],
+      resolvedAuthors: [author],
+      lastTs: 0,
+      maxAlerts: 10,
+      search,
+      resolveContext: async () => ({ chatId: "-1001", chatTitle: "T" }),
+      delay: () => Promise.resolve(),
+    })
+    expect(result.alerts).toHaveLength(1)
+    expect(search).toHaveBeenCalledTimes(1)
+    const calledPeer = search.mock.calls[0][1]
+    expect(calledPeer).toBeInstanceOf(Api.InputPeerChannel)
+  })
+
+  it("truncates total alerts to maxAlerts", async () => {
+    const many = Array.from({ length: 8 }, (_, i) => msg(String(i + 1), 100 + i))
+    const search = fakeSearch(new Map([["ch:1", many], ["ch:2", many]]))
+    const result = await collectAuthorAlerts({
+      client: {} as any,
+      peers: [chanPeer(1), chanPeer(2)],
+      resolvedAuthors: [author],
+      lastTs: 0,
+      maxAlerts: 10,
+      search,
+      resolveContext: async () => ({ chatId: "-1001", chatTitle: "T" }),
+      delay: () => Promise.resolve(),
+    })
+    expect(result.alerts).toHaveLength(10)
+  })
+
+  it("PEER_ID_INVALID / USER_DEACTIVATED on author → eviction surfaced, loop continues with next author", async () => {
+    const goodAuthor = { username: "good", resolved: { userId: "1", accessHash: "1" } }
+    const badAuthor = { username: "bad", resolved: { userId: "2", accessHash: "2" } }
+    const search = vi.fn(async (_c: any, _peer: any, resolved: any) => {
+      if (resolved.userId === "2") throw new Error("PEER_ID_INVALID")
+      return { messages: [msg("1", 100)], newLastTs: 100 }
+    })
+    const result = await collectAuthorAlerts({
+      client: {} as any,
+      peers: [chanPeer(1)],
+      resolvedAuthors: [badAuthor, goodAuthor],
+      lastTs: 0,
+      maxAlerts: 10,
+      search,
+      resolveContext: async () => ({ chatId: "-1001", chatTitle: "T" }),
+      delay: () => Promise.resolve(),
+    })
+    expect(result.evictions).toEqual(["bad"])
+    expect(result.alerts).toHaveLength(1)
+  })
+
+  it("non-eviction errors are not surfaced as evictions but loop continues", async () => {
+    const a = { username: "a", resolved: { userId: "1", accessHash: "1" } }
+    const b = { username: "b", resolved: { userId: "2", accessHash: "2" } }
+    const search = vi.fn(async (_c: any, _peer: any, resolved: any) => {
+      if (resolved.userId === "1") throw new Error("FLOOD_WAIT_42")
+      return { messages: [msg("1", 100)], newLastTs: 100 }
+    })
+    const result = await collectAuthorAlerts({
+      client: {} as any,
+      peers: [chanPeer(1)],
+      resolvedAuthors: [a, b],
+      lastTs: 0,
+      maxAlerts: 10,
+      search,
+      resolveContext: async () => ({ chatId: "-1001", chatTitle: "T" }),
+      delay: () => Promise.resolve(),
+    })
+    expect(result.evictions).toEqual([])
+    expect(result.alerts).toHaveLength(1)
+  })
+})
+
+describe("runTelegramAuthors orchestrator", () => {
+  it("persists collect.newLastTs via setTgAuthorsLastTs and broadcasts alerts", async () => {
+    const store = fakeStore({
+      getTrackedAuthors: vi.fn().mockResolvedValue(["durov"]),
+      getTgAuthorsLastTs: vi.fn().mockResolvedValue(1000),
+      getResolvedTgUser: vi.fn().mockResolvedValue({ userId: "1", accessHash: "2" }),
+      getSubscribers: vi.fn().mockResolvedValue(["chat-A"]),
+    })
+    const fakeClient = { disconnect: vi.fn().mockResolvedValue(undefined), invoke: vi.fn() }
+    const createClient = vi.fn().mockResolvedValue(fakeClient)
+    const collect = vi.fn().mockResolvedValue({
+      alerts: [{ type: "author", comment: msg("1", 200) }],
+      newLastTs: 5555,
+      evictions: [],
+    })
+    const getFolderChats = vi.fn().mockResolvedValue([chanPeer(1)])
+    const filterRecentPeers = vi.fn(async (_c: any, peers: any) => peers)
+    const broadcastAlert = vi.fn().mockResolvedValue(undefined)
+
+    const result = await runTelegramAuthors({
+      store, createClient, collect, getFolderChats, filterRecentPeers, broadcastAlert,
+      api: {} as any,
+    } as any)
+
+    expect(result.alerts).toBe(1)
+    expect(store.setTgAuthorsLastTs).toHaveBeenCalledWith(5555)
+    expect(broadcastAlert).toHaveBeenCalledTimes(1)
+    expect(fakeClient.disconnect).toHaveBeenCalled()
+  })
+
+  it("evictions trigger deleteResolvedTgUser per username", async () => {
+    const store = fakeStore({
+      getTrackedAuthors: vi.fn().mockResolvedValue(["bad", "good"]),
+      getTgAuthorsLastTs: vi.fn().mockResolvedValue(1000),
+      getResolvedTgUser: vi.fn().mockResolvedValue({ userId: "1", accessHash: "2" }),
+    })
+    const fakeClient = { disconnect: vi.fn().mockResolvedValue(undefined) }
+    const collect = vi.fn().mockResolvedValue({ alerts: [], newLastTs: 1000, evictions: ["bad"] })
+
+    await runTelegramAuthors({
+      store,
+      createClient: vi.fn().mockResolvedValue(fakeClient),
+      collect,
+      getFolderChats: vi.fn().mockResolvedValue([chanPeer(1)]),
+      filterRecentPeers: vi.fn(async (_c: any, p: any) => p),
+      broadcastAlert: vi.fn(),
+      api: {} as any,
+    } as any)
+
+    expect(store.deleteResolvedTgUser).toHaveBeenCalledWith("bad")
+    expect(store.deleteResolvedTgUser).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/sources/telegram/pipeline.test.ts
+++ b/src/sources/telegram/pipeline.test.ts
@@ -89,6 +89,8 @@ describe("collectAuthorAlerts", () => {
     // chat 2, elvis(2):  75, 125, 225, 325
     // pool (sorted): 50, 75, 100, 125, 150, 175, 200, 225, 250, 275, 300, 325, 350, 375, 400, 450
     // first 10:      50, 75, 100, 125, 150, 175, 200, 225, 250, 275  (newLastTs = 275)
+    // MTProto messages.search min_date is exclusive (date > min_date per core.telegram.org docs),
+    // so the boundary message won't be re-fetched on the next tick — no +1 needed.
     const dataset: Record<string, number[]> = {
       "ch1:1": [100, 200, 300, 400],
       "ch1:2": [150, 250, 350, 450],

--- a/src/sources/telegram/pipeline.ts
+++ b/src/sources/telegram/pipeline.ts
@@ -2,7 +2,7 @@ import type { TelegramClient } from "telegram"
 import { Api } from "telegram/tl/index.js"
 import { Store, type ResolvedTgUser } from "../../store.js"
 import { Api as BotApi } from "grammy"
-import type { Alert } from "../../types.js"
+import type { Alert, Message } from "../../types.js"
 import { telegram } from "../../config.js"
 import { searchAuthorMessages as defaultSearch, type ChatContext } from "./search.js"
 import { createClient as defaultCreateClient } from "./client.js"
@@ -49,9 +49,8 @@ export async function collectAuthorAlerts(deps: CollectDeps): Promise<CollectRes
   const delay = deps.delay ?? randomDelay
   const log = deps.log ?? (() => {})
 
-  const alerts: Alert[] = []
-  let runningMax = lastTs
-  const evictions: string[] = []
+  const pool: Message[] = []
+  const evictions = new Set<string>()
 
   for (const peer of peers) {
     if (peer instanceof Api.InputPeerUser) continue
@@ -63,28 +62,29 @@ export async function collectAuthorAlerts(deps: CollectDeps): Promise<CollectRes
       continue
     }
     for (const author of resolvedAuthors) {
-      if (alerts.length >= maxAlerts) break
       await delay()
       try {
-        const result = await search(client, peer, author.resolved, lastTs, ctx, `@${author.username}`)
-        for (const m of result.messages) {
-          if (alerts.length >= maxAlerts) break
-          alerts.push({ type: "author", comment: m })
-        }
-        if (result.newLastTs > runningMax) runningMax = result.newLastTs
+        const messages = await search(client, peer, author.resolved, lastTs, ctx, `@${author.username}`)
+        pool.push(...messages)
       } catch (e) {
         const errMsg = String(e)
         if (errMsg.includes("PEER_ID_INVALID") || errMsg.includes("USER_DEACTIVATED")) {
-          if (!evictions.includes(author.username)) evictions.push(author.username)
+          evictions.add(author.username)
         } else {
           log(`  search failed for @${author.username}: ${e}`)
         }
       }
     }
-    if (alerts.length >= maxAlerts) break
   }
 
-  return { alerts, newLastTs: runningMax, evictions }
+  pool.sort((a, b) => a.date.getTime() - b.date.getTime())
+  const selected = pool.slice(0, maxAlerts)
+  const alerts: Alert[] = selected.map((m) => ({ type: "author", comment: m }))
+  const newLastTs = selected.length > 0
+    ? Math.floor(selected[selected.length - 1].date.getTime() / 1000)
+    : lastTs
+
+  return { alerts, newLastTs, evictions: [...evictions] }
 }
 
 async function defaultResolveContext(

--- a/src/sources/telegram/pipeline.ts
+++ b/src/sources/telegram/pipeline.ts
@@ -1,0 +1,217 @@
+import type { TelegramClient } from "telegram"
+import { Api } from "telegram/tl/index.js"
+import { Store, type ResolvedTgUser } from "../../store.js"
+import { Api as BotApi } from "grammy"
+import type { Alert } from "../../types.js"
+import { telegram } from "../../config.js"
+import { searchAuthorMessages as defaultSearch, type ChatContext } from "./search.js"
+import { createClient as defaultCreateClient } from "./client.js"
+import { broadcastAlert as defaultBroadcastAlert } from "../../telegram.js"
+import {
+  getFolderChats as defaultGetFolderChats,
+  filterRecentPeers as defaultFilterRecentPeersImpl,
+} from "./reader.js"
+
+const DEFAULT_MAX_ALERTS = 10
+const DELAY_MIN = 100
+const DELAY_MAX = 500
+
+const randomDelay = () =>
+  new Promise<void>((r) => setTimeout(r, DELAY_MIN + Math.random() * (DELAY_MAX - DELAY_MIN)))
+
+export interface ResolvedAuthor {
+  username: string
+  resolved: ResolvedTgUser
+}
+
+export interface CollectDeps {
+  client: TelegramClient
+  peers: Api.TypeInputPeer[]
+  resolvedAuthors: ResolvedAuthor[]
+  lastTs: number
+  maxAlerts: number
+  search?: typeof defaultSearch
+  resolveContext?: (client: TelegramClient, peer: Api.TypeInputPeer) => Promise<ChatContext>
+  delay?: () => Promise<void>
+  log?: (msg: string) => void
+}
+
+export interface CollectResult {
+  alerts: Alert[]
+  newLastTs: number
+  evictions: string[]
+}
+
+export async function collectAuthorAlerts(deps: CollectDeps): Promise<CollectResult> {
+  const { client, peers, resolvedAuthors, lastTs, maxAlerts } = deps
+  const search = deps.search ?? defaultSearch
+  const resolveContext = deps.resolveContext ?? defaultResolveContext
+  const delay = deps.delay ?? randomDelay
+  const log = deps.log ?? (() => {})
+
+  const alerts: Alert[] = []
+  let runningMax = lastTs
+  const evictions: string[] = []
+
+  for (const peer of peers) {
+    if (peer instanceof Api.InputPeerUser) continue
+    let ctx: ChatContext
+    try {
+      ctx = await resolveContext(client, peer)
+    } catch (e) {
+      log(`  resolveContext failed: ${e}`)
+      continue
+    }
+    for (const author of resolvedAuthors) {
+      if (alerts.length >= maxAlerts) break
+      await delay()
+      try {
+        const result = await search(client, peer, author.resolved, lastTs, ctx, `@${author.username}`)
+        for (const m of result.messages) {
+          if (alerts.length >= maxAlerts) break
+          alerts.push({ type: "author", comment: m })
+        }
+        if (result.newLastTs > runningMax) runningMax = result.newLastTs
+      } catch (e) {
+        const errMsg = String(e)
+        if (errMsg.includes("PEER_ID_INVALID") || errMsg.includes("USER_DEACTIVATED")) {
+          if (!evictions.includes(author.username)) evictions.push(author.username)
+        } else {
+          log(`  search failed for @${author.username}: ${e}`)
+        }
+      }
+    }
+    if (alerts.length >= maxAlerts) break
+  }
+
+  return { alerts, newLastTs: runningMax, evictions }
+}
+
+async function defaultResolveContext(
+  client: TelegramClient,
+  peer: Api.TypeInputPeer,
+): Promise<ChatContext> {
+  const entity = await client.getEntity(peer)
+  const chatId = "id" in entity ? String(entity.id) : "unknown"
+  const chatTitle =
+    ("title" in entity ? entity.title : undefined) ??
+    ("firstName" in entity ? entity.firstName : undefined) ??
+    chatId
+  const chatUsername = "username" in entity ? entity.username ?? undefined : undefined
+  return { chatId, chatTitle, chatUsername }
+}
+
+export interface TelegramAuthorsOpts {
+  store?: Store
+  api?: BotApi
+  maxAlerts?: number
+  createClient?: () => Promise<TelegramClient>
+  collect?: typeof collectAuthorAlerts
+  getFolderChats?: (client: TelegramClient, folder: string) => Promise<Api.TypeInputPeer[]>
+  filterRecentPeers?: (
+    client: TelegramClient,
+    peers: Api.TypeInputPeer[],
+    sinceTs: number,
+  ) => Promise<Api.TypeInputPeer[]>
+  broadcastAlert?: typeof defaultBroadcastAlert
+}
+
+export interface TelegramAuthorsResult {
+  alerts: number
+}
+
+export async function runTelegramAuthors(
+  opts: TelegramAuthorsOpts = {},
+): Promise<TelegramAuthorsResult> {
+  const store = opts.store ?? new Store()
+  const tracked = await store.getTrackedAuthors("telegram")
+  if (tracked.length === 0) return { alerts: 0 }
+
+  const lastTs = await store.getTgAuthorsLastTs()
+  if (lastTs == null) {
+    await store.setTgAuthorsLastTs(Math.floor(Date.now() / 1000))
+    return { alerts: 0 }
+  }
+
+  const folder = await store.getFolder()
+  if (!folder) throw new Error("No folder configured. Use /folder <name>.")
+
+  const api = opts.api ?? new BotApi(telegram.botToken)
+  const maxAlerts = opts.maxAlerts ?? DEFAULT_MAX_ALERTS
+  const createClient = opts.createClient ?? defaultCreateClient
+  const collect = opts.collect ?? collectAuthorAlerts
+  const getFolderChats = opts.getFolderChats ?? defaultGetFolderChats
+  const filterRecentPeers = opts.filterRecentPeers ?? defaultFilterRecentPeers
+  const broadcastAlert = opts.broadcastAlert ?? defaultBroadcastAlert
+
+  const client = await createClient()
+  try {
+    const resolvedAuthors = await resolveAllAuthors(store, client, tracked)
+    if (resolvedAuthors.length === 0) return { alerts: 0 }
+
+    const peers = await getFolderChats(client, folder)
+    const active = await filterRecentPeers(client, peers, lastTs * 1000)
+
+    const result = await collect({
+      client,
+      peers: active,
+      resolvedAuthors,
+      lastTs,
+      maxAlerts,
+    })
+
+    for (const username of result.evictions) {
+      await store.deleteResolvedTgUser(username)
+    }
+
+    if (result.alerts.length > 0) {
+      const subs = await store.getSubscribers()
+      for (const alert of result.alerts) {
+        await broadcastAlert(api, subs, alert)
+      }
+    }
+
+    await store.setTgAuthorsLastTs(result.newLastTs)
+    return { alerts: result.alerts.length }
+  } finally {
+    await client.disconnect()
+  }
+}
+
+async function resolveAllAuthors(
+  store: Store,
+  client: TelegramClient,
+  usernames: string[],
+): Promise<ResolvedAuthor[]> {
+  const out: ResolvedAuthor[] = []
+  for (const username of usernames) {
+    const cached = await store.getResolvedTgUser(username)
+    if (cached) {
+      out.push({ username, resolved: cached })
+      continue
+    }
+    try {
+      const res = await client.invoke(new Api.contacts.ResolveUsername({ username }))
+      const user = res.users.find((u): u is Api.User => u instanceof Api.User)
+      if (user && user.accessHash !== undefined) {
+        const resolved: ResolvedTgUser = {
+          userId: user.id.toString(),
+          accessHash: user.accessHash.toString(),
+        }
+        await store.setResolvedTgUser(username, resolved)
+        out.push({ username, resolved })
+      }
+    } catch (e) {
+      console.log(`  resolve @${username} failed: ${e}`)
+    }
+  }
+  return out
+}
+
+async function defaultFilterRecentPeers(
+  client: TelegramClient,
+  peers: Api.TypeInputPeer[],
+  sinceTs: number,
+): Promise<Api.TypeInputPeer[]> {
+  return defaultFilterRecentPeersImpl(client, peers, sinceTs, () => {})
+}

--- a/src/sources/telegram/reader.ts
+++ b/src/sources/telegram/reader.ts
@@ -1,6 +1,7 @@
 import { TelegramClient } from "telegram"
 import { Api } from "telegram/tl/index.js"
 import type { Message } from "../../types.js"
+import { buildMessageLink } from "./link.js"
 
 const MAX_REACTIONS = 3
 
@@ -56,6 +57,7 @@ async function readChat(
     ("title" in entity ? entity.title : undefined) ??
     ("firstName" in entity ? entity.firstName : undefined) ??
     chatId
+  const chatUsername = "username" in entity ? entity.username ?? undefined : undefined
 
   if ("bot" in entity && entity.bot) {
     log(`  ${chatTitle}: skipped (bot)`)
@@ -90,6 +92,8 @@ async function readChat(
         text: msg.message,
         date: new Date(msg.date * 1000),
         reactions: extractReactions(msg),
+        linkTitle: chatTitle,
+        linkUrl: buildMessageLink(chatId, msg.id, chatUsername),
       })
       const replyToMsgId = msg.replyTo instanceof Api.MessageReplyHeader ? msg.replyTo.replyToMsgId : undefined
       if (replyToMsgId) replyIdByMsgId.set(msgId, replyToMsgId)

--- a/src/sources/telegram/reader.ts
+++ b/src/sources/telegram/reader.ts
@@ -120,7 +120,7 @@ function peerKey(peer: Api.TypePeer | Api.TypeInputPeer): string {
   return "unknown"
 }
 
-async function filterRecentPeers(
+export async function filterRecentPeers(
   client: TelegramClient,
   peers: Api.TypeInputPeer[],
   sinceTs: number,

--- a/src/sources/telegram/resolve.ts
+++ b/src/sources/telegram/resolve.ts
@@ -1,0 +1,17 @@
+import { Api } from "telegram/tl/index.js"
+import { createClient } from "./client.js"
+import type { ResolvedTgUser } from "../../store.js"
+
+export async function resolveTgUsername(username: string): Promise<ResolvedTgUser | null> {
+  const client = await createClient()
+  try {
+    const res = await client.invoke(new Api.contacts.ResolveUsername({ username }))
+    const user = res.users.find((u): u is Api.User => u instanceof Api.User)
+    if (!user || user.accessHash === undefined) return null
+    return { userId: user.id.toString(), accessHash: user.accessHash.toString() }
+  } catch {
+    return null
+  } finally {
+    await client.disconnect()
+  }
+}

--- a/src/sources/telegram/search.test.ts
+++ b/src/sources/telegram/search.test.ts
@@ -30,11 +30,10 @@ describe("searchAuthorMessages", () => {
       chatId: "-1001234567890",
       chatTitle: "Test",
     })
-    expect(result.messages).toEqual([])
-    expect(result.newLastTs).toBe(1000)
+    expect(result).toEqual([])
   })
 
-  it("len < 100 → all messages, newLastTs = max(date), oldest-first", async () => {
+  it("returns all messages oldest-first", async () => {
     // Telegram returns newest-first
     const raw = [makeMsg(3, 300, "c"), makeMsg(2, 200, "b"), makeMsg(1, 100, "a")]
     const client = mockClient(raw)
@@ -42,20 +41,19 @@ describe("searchAuthorMessages", () => {
       chatId: "-1001234567890",
       chatTitle: "Test",
     })
-    expect(result.messages.map((m) => m.text)).toEqual(["a", "b", "c"])
-    expect(result.newLastTs).toBe(300)
+    expect(result.map((m) => m.text)).toEqual(["a", "b", "c"])
   })
 
-  it("len === 100 → first 10 oldest-first, newLastTs = date[9]", async () => {
+  it("does not cap — returns up to SEARCH_LIMIT messages", async () => {
     const raw = Array.from({ length: 100 }, (_, i) => makeMsg(100 - i, 1000 - i, `m${100 - i}`))
     const client = mockClient(raw)
     const result = await searchAuthorMessages(client, peer, author, 0, {
       chatId: "-1001234567890",
       chatTitle: "Test",
     })
-    expect(result.messages).toHaveLength(10)
-    expect(result.messages.map((m) => m.text)).toEqual(["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9", "m10"])
-    expect(result.newLastTs).toBe(910)
+    expect(result).toHaveLength(100)
+    expect(result.slice(0, 3).map((m) => m.text)).toEqual(["m1", "m2", "m3"])
+    expect(result.at(-1)!.text).toBe("m100")
   })
 
   it("aggregates likes as sum of all reactions counts", async () => {
@@ -65,7 +63,7 @@ describe("searchAuthorMessages", () => {
       chatId: "-1001234567890",
       chatTitle: "Test",
     })
-    expect(result.messages[0].likes).toBe(10)
+    expect(result[0].likes).toBe(10)
   })
 
   it("populates linkTitle, linkUrl via buildMessageLink", async () => {
@@ -76,15 +74,15 @@ describe("searchAuthorMessages", () => {
       chatTitle: "Public",
       chatUsername: "durov",
     })
-    expect(pub.messages[0].linkTitle).toBe("Public")
-    expect(pub.messages[0].linkUrl).toBe("https://t.me/durov/42")
+    expect(pub[0].linkTitle).toBe("Public")
+    expect(pub[0].linkUrl).toBe("https://t.me/durov/42")
 
     const clientPriv = mockClient([makeMsg(7, 100, "y")])
     const priv = await searchAuthorMessages(clientPriv, peer, author, 0, {
       chatId: "-1001234567890",
       chatTitle: "Private",
     })
-    expect(priv.messages[0].linkUrl).toBe("https://t.me/c/1234567890/7")
+    expect(priv[0].linkUrl).toBe("https://t.me/c/1234567890/7")
   })
 
   it("invokes messages.Search with correct params", async () => {

--- a/src/sources/telegram/search.test.ts
+++ b/src/sources/telegram/search.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from "vitest"
+import { Api } from "telegram/tl/index.js"
+import { searchAuthorMessages } from "./search.js"
+import type { ResolvedTgUser } from "../../store.js"
+
+const author: ResolvedTgUser = { userId: "100", accessHash: "200" }
+const peer = new Api.InputPeerChannel({ channelId: BigInt(123) as any, accessHash: BigInt(456) as any })
+
+function makeMsg(id: number, date: number, text: string, reactions?: { count: number }[]): Api.Message {
+  const reactionsObj = reactions
+    ? new Api.MessageReactions({
+        results: reactions.map(
+          (r) => new Api.ReactionCount({ reaction: new Api.ReactionEmoji({ emoticon: "👍" }), count: r.count }),
+        ),
+      })
+    : undefined
+  const m = Object.create(Api.Message.prototype) as Api.Message
+  Object.assign(m, { id, date, message: text, reactions: reactionsObj })
+  return m
+}
+
+function mockClient(messages: Api.Message[]) {
+  return { invoke: vi.fn().mockResolvedValue({ messages }) } as any
+}
+
+describe("searchAuthorMessages", () => {
+  it("returns empty list when no messages", async () => {
+    const client = mockClient([])
+    const result = await searchAuthorMessages(client, peer, author, 1000, {
+      chatId: "-1001234567890",
+      chatTitle: "Test",
+    })
+    expect(result.messages).toEqual([])
+    expect(result.newLastTs).toBe(1000)
+  })
+
+  it("len < 100 → all messages, newLastTs = max(date), oldest-first", async () => {
+    // Telegram returns newest-first
+    const raw = [makeMsg(3, 300, "c"), makeMsg(2, 200, "b"), makeMsg(1, 100, "a")]
+    const client = mockClient(raw)
+    const result = await searchAuthorMessages(client, peer, author, 50, {
+      chatId: "-1001234567890",
+      chatTitle: "Test",
+    })
+    expect(result.messages.map((m) => m.text)).toEqual(["a", "b", "c"])
+    expect(result.newLastTs).toBe(300)
+  })
+
+  it("len === 100 → first 10 oldest-first, newLastTs = date[9]", async () => {
+    const raw = Array.from({ length: 100 }, (_, i) => makeMsg(100 - i, 1000 - i, `m${100 - i}`))
+    const client = mockClient(raw)
+    const result = await searchAuthorMessages(client, peer, author, 0, {
+      chatId: "-1001234567890",
+      chatTitle: "Test",
+    })
+    expect(result.messages).toHaveLength(10)
+    expect(result.messages.map((m) => m.text)).toEqual(["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8", "m9", "m10"])
+    expect(result.newLastTs).toBe(910)
+  })
+
+  it("aggregates likes as sum of all reactions counts", async () => {
+    const raw = [makeMsg(1, 100, "x", [{ count: 5 }, { count: 3 }, { count: 2 }])]
+    const client = mockClient(raw)
+    const result = await searchAuthorMessages(client, peer, author, 0, {
+      chatId: "-1001234567890",
+      chatTitle: "Test",
+    })
+    expect(result.messages[0].likes).toBe(10)
+  })
+
+  it("populates linkTitle, linkUrl via buildMessageLink", async () => {
+    const raw = [makeMsg(42, 100, "x")]
+    const clientPub = mockClient(raw)
+    const pub = await searchAuthorMessages(clientPub, peer, author, 0, {
+      chatId: "-1001234567890",
+      chatTitle: "Public",
+      chatUsername: "durov",
+    })
+    expect(pub.messages[0].linkTitle).toBe("Public")
+    expect(pub.messages[0].linkUrl).toBe("https://t.me/durov/42")
+
+    const clientPriv = mockClient([makeMsg(7, 100, "y")])
+    const priv = await searchAuthorMessages(clientPriv, peer, author, 0, {
+      chatId: "-1001234567890",
+      chatTitle: "Private",
+    })
+    expect(priv.messages[0].linkUrl).toBe("https://t.me/c/1234567890/7")
+  })
+
+  it("invokes messages.Search with correct params", async () => {
+    const client = mockClient([])
+    await searchAuthorMessages(client, peer, author, 12345, {
+      chatId: "-1001234567890",
+      chatTitle: "Test",
+    })
+    const call = client.invoke.mock.calls[0][0]
+    expect(call).toBeInstanceOf(Api.messages.Search)
+    expect(call.minDate).toBe(12345)
+    expect(call.limit).toBe(100)
+    expect(call.q).toBe("")
+    expect(call.filter).toBeInstanceOf(Api.InputMessagesFilterEmpty)
+    expect(call.fromId).toBeInstanceOf(Api.InputPeerUser)
+  })
+})

--- a/src/sources/telegram/search.ts
+++ b/src/sources/telegram/search.ts
@@ -5,17 +5,11 @@ import type { ResolvedTgUser } from "../../store.js"
 import { buildMessageLink } from "./link.js"
 
 const SEARCH_LIMIT = 100
-const MAX_PER_TICK = 10
 
 export interface ChatContext {
   chatId: string
   chatTitle: string
   chatUsername?: string
-}
-
-export interface SearchResult {
-  messages: Message[]
-  newLastTs: number
 }
 
 function sumReactions(msg: Api.Message): number | undefined {
@@ -45,7 +39,7 @@ export async function searchAuthorMessages(
   sinceTs: number,
   ctx: ChatContext,
   authorLabel = "",
-): Promise<SearchResult> {
+): Promise<Message[]> {
   const fromId = new Api.InputPeerUser({
     userId: BigInt(resolvedUser.userId) as any,
     accessHash: BigInt(resolvedUser.accessHash) as any,
@@ -72,20 +66,5 @@ export async function searchAuthorMessages(
     (m): m is Api.Message => m instanceof Api.Message,
   )
 
-  if (raw.length === 0) return { messages: [], newLastTs: sinceTs }
-
-  const oldestFirst = [...raw].sort((a, b) => a.date - b.date)
-
-  if (oldestFirst.length === SEARCH_LIMIT) {
-    const slice = oldestFirst.slice(0, MAX_PER_TICK)
-    return {
-      messages: slice.map((m) => toMessage(m, ctx, authorLabel)),
-      newLastTs: slice[slice.length - 1].date,
-    }
-  }
-
-  return {
-    messages: oldestFirst.map((m) => toMessage(m, ctx, authorLabel)),
-    newLastTs: oldestFirst[oldestFirst.length - 1].date,
-  }
+  return raw.sort((a, b) => a.date - b.date).map((m) => toMessage(m, ctx, authorLabel))
 }

--- a/src/sources/telegram/search.ts
+++ b/src/sources/telegram/search.ts
@@ -1,0 +1,91 @@
+import type { TelegramClient } from "telegram"
+import { Api } from "telegram/tl/index.js"
+import type { Message } from "../../types.js"
+import type { ResolvedTgUser } from "../../store.js"
+import { buildMessageLink } from "./link.js"
+
+const SEARCH_LIMIT = 100
+const MAX_PER_TICK = 10
+
+export interface ChatContext {
+  chatId: string
+  chatTitle: string
+  chatUsername?: string
+}
+
+export interface SearchResult {
+  messages: Message[]
+  newLastTs: number
+}
+
+function sumReactions(msg: Api.Message): number | undefined {
+  const results = msg.reactions?.results
+  if (!results?.length) return undefined
+  return results.reduce((sum, r) => sum + r.count, 0)
+}
+
+function toMessage(msg: Api.Message, ctx: ChatContext, author: string): Message {
+  return {
+    id: String(msg.id),
+    chatId: ctx.chatId,
+    chatTitle: ctx.chatTitle,
+    author,
+    text: msg.message ?? "",
+    date: new Date(msg.date * 1000),
+    likes: sumReactions(msg),
+    linkTitle: ctx.chatTitle,
+    linkUrl: buildMessageLink(ctx.chatId, msg.id, ctx.chatUsername),
+  }
+}
+
+export async function searchAuthorMessages(
+  client: TelegramClient,
+  peer: Api.TypeInputPeer,
+  resolvedUser: ResolvedTgUser,
+  sinceTs: number,
+  ctx: ChatContext,
+  authorLabel = "",
+): Promise<SearchResult> {
+  const fromId = new Api.InputPeerUser({
+    userId: BigInt(resolvedUser.userId) as any,
+    accessHash: BigInt(resolvedUser.accessHash) as any,
+  })
+
+  const res = await client.invoke(
+    new Api.messages.Search({
+      peer,
+      fromId,
+      q: "",
+      filter: new Api.InputMessagesFilterEmpty(),
+      minDate: sinceTs,
+      maxDate: 0,
+      offsetId: 0,
+      addOffset: 0,
+      limit: SEARCH_LIMIT,
+      maxId: 0,
+      minId: 0,
+      hash: BigInt(0) as any,
+    }),
+  )
+
+  const raw = (res as { messages: Api.Message[] }).messages.filter(
+    (m): m is Api.Message => m instanceof Api.Message,
+  )
+
+  if (raw.length === 0) return { messages: [], newLastTs: sinceTs }
+
+  const oldestFirst = [...raw].sort((a, b) => a.date - b.date)
+
+  if (oldestFirst.length === SEARCH_LIMIT) {
+    const slice = oldestFirst.slice(0, MAX_PER_TICK)
+    return {
+      messages: slice.map((m) => toMessage(m, ctx, authorLabel)),
+      newLastTs: slice[slice.length - 1].date,
+    }
+  }
+
+  return {
+    messages: oldestFirst.map((m) => toMessage(m, ctx, authorLabel)),
+    newLastTs: oldestFirst[oldestFirst.length - 1].date,
+  }
+}

--- a/src/sources/telegram/username.test.ts
+++ b/src/sources/telegram/username.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest"
+import { normalizeTgUsername } from "./username.js"
+
+describe("normalizeTgUsername", () => {
+  it("strips @ and lowercases", () => {
+    expect(normalizeTgUsername("@DUROV")).toBe("durov")
+  })
+
+  it("returns null without leading @", () => {
+    expect(normalizeTgUsername("durov")).toBeNull()
+  })
+
+  it("returns null for empty body after @", () => {
+    expect(normalizeTgUsername("@")).toBeNull()
+  })
+})

--- a/src/sources/telegram/username.ts
+++ b/src/sources/telegram/username.ts
@@ -1,0 +1,5 @@
+export function normalizeTgUsername(input: string): string | null {
+  if (!input.startsWith("@")) return null
+  const body = input.slice(1).toLowerCase()
+  return body.length ? body : null
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -93,10 +93,36 @@ describe("Store", () => {
     expect(redis.sadd).toHaveBeenCalledWith("topics:tracked", "SBER")
   })
 
-  it("trackAuthor adds to set", async () => {
+  it("trackAuthor writes to per-source key", async () => {
     redis.sadd.mockResolvedValue(1)
-    await store.trackAuthor("elvis")
-    expect(redis.sadd).toHaveBeenCalledWith("authors:tracked", "elvis")
+    await store.trackAuthor("alenka", "elvis")
+    expect(redis.sadd).toHaveBeenCalledWith("authors:tracked:alenka", "elvis")
+  })
+
+  it("tracked authors are isolated per source", async () => {
+    redis.sadd.mockResolvedValue(1)
+    await store.trackAuthor("alenka", "x")
+    await store.trackAuthor("telegram", "y")
+    expect(redis.sadd).toHaveBeenCalledWith("authors:tracked:alenka", "x")
+    expect(redis.sadd).toHaveBeenCalledWith("authors:tracked:telegram", "y")
+  })
+
+  it("getTrackedAuthors reads per-source key", async () => {
+    redis.smembers.mockResolvedValue(["a"])
+    await store.getTrackedAuthors("telegram")
+    expect(redis.smembers).toHaveBeenCalledWith("authors:tracked:telegram")
+  })
+
+  it("untrackAuthor removes from per-source key", async () => {
+    redis.srem.mockResolvedValue(1)
+    await store.untrackAuthor("telegram", "x")
+    expect(redis.srem).toHaveBeenCalledWith("authors:tracked:telegram", "x")
+  })
+
+  it("isTrackedAuthor checks per-source key", async () => {
+    redis.sismember.mockResolvedValue(1)
+    expect(await store.isTrackedAuthor("alenka", "elvis")).toBe(true)
+    expect(redis.sismember).toHaveBeenCalledWith("authors:tracked:alenka", "elvis")
   })
 
   it("isHotSeen checks existence", async () => {

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -125,6 +125,29 @@ describe("Store", () => {
     expect(redis.sismember).toHaveBeenCalledWith("authors:tracked:alenka", "elvis")
   })
 
+  it("setResolvedTgUser writes per-username key with 7d TTL and string-serialized ids", async () => {
+    redis.set.mockResolvedValue("OK")
+    await store.setResolvedTgUser("durov", { userId: "1", accessHash: "-2245008065968966897" })
+    expect(redis.set).toHaveBeenCalledWith(
+      "source:telegram:authors:resolved:durov",
+      { userId: "1", accessHash: "-2245008065968966897" },
+      { ex: 604800 },
+    )
+  })
+
+  it("getResolvedTgUser reads per-username key", async () => {
+    redis.get.mockResolvedValue({ userId: "1", accessHash: "2" })
+    const result = await store.getResolvedTgUser("durov")
+    expect(redis.get).toHaveBeenCalledWith("source:telegram:authors:resolved:durov")
+    expect(result).toEqual({ userId: "1", accessHash: "2" })
+  })
+
+  it("deleteResolvedTgUser deletes per-username key", async () => {
+    redis.del.mockResolvedValue(1)
+    await store.deleteResolvedTgUser("durov")
+    expect(redis.del).toHaveBeenCalledWith("source:telegram:authors:resolved:durov")
+  })
+
   it("isHotSeen checks existence", async () => {
     redis.exists.mockResolvedValue(0)
     expect(await store.isHotSeen("c123")).toBe(false)

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -148,6 +148,18 @@ describe("Store", () => {
     expect(redis.del).toHaveBeenCalledWith("source:telegram:authors:resolved:durov")
   })
 
+  it("getTgAuthorsLastTs reads source:telegram:authors:lastTs", async () => {
+    redis.get.mockResolvedValue(1730000000)
+    expect(await store.getTgAuthorsLastTs()).toBe(1730000000)
+    expect(redis.get).toHaveBeenCalledWith("source:telegram:authors:lastTs")
+  })
+
+  it("setTgAuthorsLastTs stores unix seconds", async () => {
+    redis.set.mockResolvedValue("OK")
+    await store.setTgAuthorsLastTs(1730000000)
+    expect(redis.set).toHaveBeenCalledWith("source:telegram:authors:lastTs", 1730000000)
+  })
+
   it("isHotSeen checks existence", async () => {
     redis.exists.mockResolvedValue(0)
     expect(await store.isHotSeen("c123")).toBe(false)

--- a/src/store.ts
+++ b/src/store.ts
@@ -88,7 +88,9 @@ export class Store {
   }
 
   private topics = this.trackedSet("topics:tracked")
-  private authors = this.trackedSet("authors:tracked")
+  private authors(source: "alenka" | "telegram") {
+    return this.trackedSet(`authors:tracked:${source}`)
+  }
 
   // Topics (shared across all sources)
   trackTopic = (name: string) => this.topics.add(name)
@@ -96,11 +98,11 @@ export class Store {
   getTrackedTopics = () => this.topics.members()
   isTrackedTopic = (name: string) => this.topics.has(name)
 
-  // Authors (alenka-specific)
-  trackAuthor = (name: string) => this.authors.add(name)
-  untrackAuthor = (name: string) => this.authors.remove(name)
-  getTrackedAuthors = () => this.authors.members()
-  isTrackedAuthor = (name: string) => this.authors.has(name)
+  // Authors (per-source)
+  trackAuthor = (source: "alenka" | "telegram", name: string) => this.authors(source).add(name)
+  untrackAuthor = (source: "alenka" | "telegram", name: string) => this.authors(source).remove(name)
+  getTrackedAuthors = (source: "alenka" | "telegram") => this.authors(source).members()
+  isTrackedAuthor = (source: "alenka" | "telegram", name: string) => this.authors(source).has(name)
 
   // Hot comments seen (alenka-specific, 3-day TTL per comment)
   async isHotSeen(commentId: string): Promise<boolean> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -9,8 +9,14 @@ export interface Session {
 
 const ONE_DAY = 86_400
 const THREE_DAYS = 3 * ONE_DAY
+const SEVEN_DAYS = 7 * ONE_DAY
 const FIVE_MINUTES = 300
 const FOUR_HOURS = 4 * 3_600
+
+export interface ResolvedTgUser {
+  userId: string
+  accessHash: string
+}
 
 export class Store {
   private redis: Redis
@@ -103,6 +109,19 @@ export class Store {
   untrackAuthor = (source: "alenka" | "telegram", name: string) => this.authors(source).remove(name)
   getTrackedAuthors = (source: "alenka" | "telegram") => this.authors(source).members()
   isTrackedAuthor = (source: "alenka" | "telegram", name: string) => this.authors(source).has(name)
+
+  // Resolved TG username cache (7-day TTL per username)
+  async setResolvedTgUser(username: string, value: ResolvedTgUser): Promise<void> {
+    await this.redis.set(`source:telegram:authors:resolved:${username}`, value, { ex: SEVEN_DAYS })
+  }
+
+  async getResolvedTgUser(username: string): Promise<ResolvedTgUser | null> {
+    return this.redis.get<ResolvedTgUser>(`source:telegram:authors:resolved:${username}`)
+  }
+
+  async deleteResolvedTgUser(username: string): Promise<void> {
+    await this.redis.del(`source:telegram:authors:resolved:${username}`)
+  }
 
   // Hot comments seen (alenka-specific, 3-day TTL per comment)
   async isHotSeen(commentId: string): Promise<boolean> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -123,6 +123,14 @@ export class Store {
     await this.redis.del(`source:telegram:authors:resolved:${username}`)
   }
 
+  async getTgAuthorsLastTs(): Promise<number | null> {
+    return this.redis.get<number>("source:telegram:authors:lastTs")
+  }
+
+  async setTgAuthorsLastTs(ts: number): Promise<void> {
+    await this.redis.set("source:telegram:authors:lastTs", ts)
+  }
+
   // Hot comments seen (alenka-specific, 3-day TTL per comment)
   async isHotSeen(commentId: string): Promise<boolean> {
     return (await this.redis.exists(`hot:seen:${commentId}`)) === 1

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -59,10 +59,9 @@ describe("formatTrendsSummary", () => {
 const comment: Message = {
   id: "123", author: "Элвис Марламов",
   chatId: "c1", chatTitle: "Test",
-  text: "Эффект золота", articleTitle: "Предложи новость!",
-  articleUrl: "https://alenka.capital/a/1",
+  text: "Эффект золота", linkTitle: "Предложи новость!",
   date: new Date(), likes: 5,
-  commentUrl: "https://alenka.capital/a/1?comm_find=123",
+  linkUrl: "https://alenka.capital/a/1?comm_find=123",
   images: ["https://cdn.alenka.capital/abc.png"],
 }
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -28,8 +28,8 @@ function shortDate(d: Date): string {
 function formatCommentAlert(emoji: string, c: Message): string {
   const reply = c.replyTo ? ` → ${esc(c.replyTo)}` : ""
   const likes = c.likes ? ` · ${c.likes > 0 ? `${c.likes}+` : c.likes}` : ""
-  const link = c.commentUrl && c.articleTitle
-    ? `<a href="${c.commentUrl}">${esc(c.articleTitle)}</a>`
+  const link = c.linkUrl && c.linkTitle
+    ? `<a href="${c.linkUrl}">${esc(c.linkTitle)}</a>`
     : ""
   const header = `${emoji} <b>${esc(c.author)}</b>${reply} · ${formatDateShort(c.date)}${likes}`
   const shell = `${header}\n\n\n\n${link}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,9 +9,8 @@ export interface Message {
   reactions?: { emoji: string; count: number }[]
   likes?: number
   images?: string[]
-  articleTitle?: string
-  articleUrl?: string
-  commentUrl?: string
+  linkTitle?: string
+  linkUrl?: string
 }
 
 export type HotAlert = { type: "hot"; comment: Message }

--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,7 @@
     "api/cron/telegram-trends.ts": { "memory": 1024, "includeFiles": "prompts/**" },
     "api/cron/alenka-trends.ts": { "memory": 1024, "includeFiles": "prompts/**" },
     "api/cron/alenka-authors.ts": { "memory": 1024 },
-    "api/cron/alenka-hot.ts": { "memory": 1024 }
+    "api/cron/alenka-hot.ts": { "memory": 1024 },
+    "api/cron/telegram-authors.ts": { "memory": 1024 }
   }
 }


### PR DESCRIPTION
## Summary

Закрывает epic #6 (TG author tracking по @username) — все 5 слайсов.

- **#7** — Message: `articleUrl` → `linkTitle`/`linkUrl` (источник-агностичные поля).
- **#8** — Per-source namespace `authors:tracked:{alenka|telegram}` + idempotent migration.
- **#9** — `/follow @x` через `contacts.ResolveUsername` + 7d resolve-cache; toggle вытесняет кэш; source-aware list/write.
- **#10** — `buildMessageLink` (public/private), `searchAuthorMessages` (oldest-first, cap 10/tick, reactions→likes), `lastTs` get/set.
- **#11** — `runTelegramAuthors` orchestration: cold-start init, peer-prefilter `filterRecentPeers`, eviction `PEER_ID_INVALID`/`USER_DEACTIVATED`, DM-skip, broadcast подписчикам, running max `lastTs`. Cron `/api/cron/telegram-authors` (mirror `alenka-authors`). Bot dispatch `runAuthorsForSource` по активному source.

Алёрт: `✍️ @username · DD.MM HH:MM · Nlikes` + кликабельный заголовок чата → deep-link на сообщение.

## Test plan

- [x] `npm test` — 102/102 passed (новые: `pipeline.test.ts` 8, `search.test.ts` 6, `link.test.ts` 4, `username.test.ts` 3, `authors-dispatch.test.ts` 2)
- [x] `npm run typecheck` — clean
- [x] Manual smoke E2E через `npm run dev:bot`:
  - Cold-start: пустой `lastTs` → 0 алертов, ставит `now`
  - Real run: `lastTs := now-7d` → алёрты пришли подписчикам, running max обновился до даты последнего сообщения
  - Шапка корректна, deep-link открывает конкретное сообщение
  - Кнопка ✍️ Авторы видна только при выбранном TG-источнике
- [x] Cron endpoint — проверка после auto-deploy на main (контракт идентичен `alenka-authors`)
- [x] Запустить `scripts/migrate-authors.ts` против prod Redis перед merge (one-shot, идемпотентен)

Closes #6, #7, #8, #9, #10, #11